### PR TITLE
Expose KubeClientSelector.host_client property

### DIFF
--- a/tests/unit/test_http_session_sharing.py
+++ b/tests/unit/test_http_session_sharing.py
@@ -52,7 +52,7 @@ async def test_selector_uses_shared_session(create_namespace_mock: AsyncMock) ->
     )
 
     secret = build_vcluster_secret(server="http://k1.local")
-    selector._default_client.core_v1.secret.get = AsyncMock(  # type: ignore[method-assign]
+    selector._host_client.core_v1.secret.get = AsyncMock(  # type: ignore[method-assign]
         side_effect=[ResourceNotFound(), secret]
     )
 


### PR DESCRIPTION
Rename internal `_default_client` to `_host_client` as VCluster constantly use *host* for host kubernetes