### PR TITLE
IT-126: fix ingress-gateway egress rule dropping its namespaceSelector

### DIFF
--- a/apolo_kube_client/apolo.py
+++ b/apolo_kube_client/apolo.py
@@ -180,7 +180,7 @@ async def create_namespace(
                 V1NetworkPolicyEgressRule(
                     to=[
                         V1NetworkPolicyPeer(
-                            namespace_selector=V1LabelSelector(),
+                            namespace_selector=V1LabelSelector(match_labels={}),
                             pod_selector=V1LabelSelector(
                                 match_labels={COMPONENT_LABEL: "ingress-gateway"}
                             ),


### PR DESCRIPTION
## Problem
The per-project egress `NetworkPolicy` built in `create_namespace` has an "allow traffic to ingress gateway" rule that used `namespace_selector=V1LabelSelector()` (empty). An all-`None` `V1LabelSelector` is **dropped during `model_dump(mode="json")` serialization**, so the applied peer becomes `podSelector`-only:

```yaml
- to:
  - podSelector:
      matchLabels:
        platform.apolo.us/component: ingress-gateway
```

k8s scopes a `podSelector`-only egress peer to the policy's **own namespace**. The ingress gateway (traefik) runs in the `platform` namespace, so project pods can't reach it. This makes in-cluster registry pushes and app→ingress calls (e.g. Launchpad → its external Keycloak URL) time out.

Verified: dev platform-api runs apolo-kube-client 25.12.1 (whose code already had `V1LabelSelector()`), yet the stored policy is `podSelector`-only.

## Fix
Use `V1LabelSelector(match_labels={})`, which serializes to an explicit `namespaceSelector: {}` (all namespaces):

```
V1LabelSelector()            -> {"podSelector": {...}}                       # namespaceSelector dropped
V1LabelSelector(match_labels={}) -> {"namespaceSelector": {}, "podSelector": {...}}  # correct
```

`namespaceSelector: {}` reads back as an empty `V1LabelSelector()`, matching the existing expectation in `tests/integration/test_apolo_namespace.py`.

## Companion change
Requires the ingress pods to carry `platform.apolo.us/component: ingress-gateway`. On user clusters `platform-operator` sets this; GKE control planes get it via cloud-infra PR #491. Both are needed. Tracked in IT-126.