### PR TITLE
IT-128: fix red CI — drop unused poetry-plugin-export (incompatible with poetry 2.0.1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,7 @@ venv:
 
 .PHONY: poetry-plugins
 poetry-plugins:
-	poetry self add "poetry-dynamic-versioning[plugin]"; \
-    poetry self add "poetry-plugin-export";
+	poetry self add "poetry-dynamic-versioning[plugin]";
 
 .PHONY: setup
 setup: venv poetry-plugins


### PR DESCRIPTION
## Problem
master CI is red: every `unit_tests` / `integration_tests` run (and the nightly schedule) fails at **Install dependencies** (`make setup` → `poetry-plugins`), before any test/lint. This also blocks releases — `deploy (Release client)` has `needs: check` → `needs: [unit_tests, integration_tests]`, so tags can't publish to PyPI.

## Root cause
`poetry self add "poetry-plugin-export"` (no constraint) installs the latest `poetry-plugin-export 1.10.0`, which **requires poetry >=2.1.0**; CI installs **poetry 2.0.1**:
```
Because no versions of poetry-plugin-export match >1.10.0,<2.0.0
poetry (2.0.1) and poetry-plugin-export (^1.10.0) -> version solving failed
make: *** [Makefile:14: poetry-plugins] Error 1
```
The plugin is **unused** — no `poetry export` / requirements export anywhere in the repo (boilerplate since the init commit).

## Fix
Drop the `poetry self add "poetry-plugin-export"` line. Keep `poetry-dynamic-versioning`, which is required for tag-based versioning/release.

Not caused by any recent code change — nightly runs were red before. Unblocks the IT-126 release (`v25.12.2`). Ref: IT-128.